### PR TITLE
Switching 'game' to ID instead of Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ It gets the game by its name
 from twitch.twitch import Twitch
 
 async with Twitch("client_id","client_secret") as example_name:
-    await example_name.game('game name')
+    await example_name.game('game ID')
 ```
 This can be done for multiple games too
 ```

--- a/twitch/twitchapp.py
+++ b/twitch/twitchapp.py
@@ -144,13 +144,13 @@ class TwitchApp:
     async def game(self, games: Union[list, str]):
         """
         Searches after one or more games on Twitch
-        :param games: Name/s of the game/s
+        :param games: ID/s of the game/s
         :return:
         """
         games = games if type(games) is list else [games]
         response_games = []
         for i in range(int(len(games) / 100) + 1):
-            query = "&".join(f"name={game}" for game in games[100 * i:100 * (i + 1)])
+            query = "&".join(f"id={game}" for game in games[100 * i:100 * (i + 1)])
             url = f'https://api.twitch.tv/helix/games?{query}'
             part_games = await self.session.get(url, headers=self.header)
             async with part_games:


### PR DESCRIPTION
Just wanna start with the fact that this is an amazing Python library for the new Twitch API.
I found myself in a situation where I wanted to grab what game a streamer was playing from an active 'stream' object and thought this might be the best way to go about it.
Edit: Forgot to mention my main point, 'stream' objects only have access to the games ID and not it's name. By searching from ID we're able to grab it like so.

Cheers,
Agnew :)